### PR TITLE
Fix/fix wrong references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,7 @@ dependencies = [
 name = "coeus_models"
 version = "0.1.1"
 dependencies = [
+ "abxml",
  "bitflags",
  "cesu8",
  "coeus_macros",

--- a/coeus-python/Cargo.lock
+++ b/coeus-python/Cargo.lock
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "coeus-python"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "coeus",
  "pyo3",
@@ -218,6 +218,7 @@ dependencies = [
 name = "coeus_models"
 version = "0.1.1"
 dependencies = [
+ "abxml",
  "bitflags",
  "cesu8",
  "coeus_macros",

--- a/coeus-python/Cargo.toml
+++ b/coeus-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coeus-python"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/coeus-python/coeus_python.pyi
+++ b/coeus-python/coeus_python.pyi
@@ -99,6 +99,8 @@ class Evidence:
         """Interpret this `Evidence` as a `Class`. Raises a `RuntimeException` if it cannot be cast."""
     def as_string(self) -> DexString:
         """Interpret this `Evidence` as a `String`. Raises a `RuntimeException` if it cannot be cast."""
+    def as_field_access(self) -> FieldAccess:
+        """Interpret this `Evidence` as a `FieldAccess`. Raises a `RuntimeException` if it cannot be cast."""
     def as_field(self) -> DexField:
         """Interpret this `Evidence` as a `Field`. Raises a `RuntimeException` if it cannot be cast."""
     def as_native_symbol(self) -> NativeSymbol:

--- a/coeus-python/coeus_python.pyi
+++ b/coeus-python/coeus_python.pyi
@@ -50,7 +50,7 @@ class DexVm:
     
 class VmResult:
     def get_value(self) -> Any:
-        """"Cast the VmResult to a python native type"""
+        """Cast the VmResult to a python native type"""
 class DexClassObject:
     pass
 class DexString:

--- a/coeus-python/src/parse.rs
+++ b/coeus-python/src/parse.rs
@@ -143,6 +143,12 @@ impl AnalyzeObject {
         let mut results = vec![];
         for key in self.files.binaries.keys() {
             if key.contains(name) {
+                if key.ends_with(".xml") {
+                    if let Some(xml) = self.files.decode_resource(self.files.binaries[key].data()) {
+                        results.push((key.clone(), xml.as_bytes().to_vec()));
+                        continue;
+                    }
+                } 
                 results.push((key.clone(), self.files.binaries[key].data().to_vec()));
             }
         }

--- a/coeus/Cargo.lock
+++ b/coeus/Cargo.lock
@@ -219,6 +219,7 @@ dependencies = [
 name = "coeus_models"
 version = "0.1.1"
 dependencies = [
+ "abxml",
  "bitflags",
  "cesu8",
  "coeus_macros",

--- a/coeus/coeus_analysis/src/analysis/dex.rs
+++ b/coeus/coeus_analysis/src/analysis/dex.rs
@@ -382,7 +382,7 @@ fn find_references_to_type<'a: 'b, 'b>(
             .map(|m| {
                 Evidence::CrossReference(CrossReferenceEvidence {
                     place: Location::DexMethod(m.method.method_idx as u32, dex_file.clone()),
-                    place_context: Context::DexMethod(m.method.clone(), dex_file.clone()),
+                    place_context: Context::DexMethod(m.method.clone(), f.clone()),
                     context: place.clone(),
                 })
             })

--- a/coeus/coeus_analysis/src/analysis/dex.rs
+++ b/coeus/coeus_analysis/src/analysis/dex.rs
@@ -111,8 +111,8 @@ pub fn find_cross_reference(place: &Context, multi_dex: &MultiDexFile) -> Vec<Ev
         Context::DexClass(class, dex_file) => {
             find_references_to_class(class, dex_file.clone(), multi_dex, place)
         }
-        Context::DexType(typ, _, dex_file) => {
-            find_references_to_type(*typ, dex_file.clone(), multi_dex, place)
+        Context::DexType(typ, name, dex_file) => {
+            find_references_to_type(*typ, name, dex_file.clone(), multi_dex, place)
         }
         Context::DexMethod(method, dex_file) => {
             find_references_to_method(method, dex_file.clone(), multi_dex, place)
@@ -154,7 +154,7 @@ pub fn find_cross_reference_array<'a: 'b, 'b>(
                     };
                     new_place = Context::DexType(*typ, name.to_string(), dex_file.clone());
 
-                    find_references_to_type(*typ, dex_file, multi_dex, &new_place)
+                    find_references_to_type(*typ, name, dex_file, multi_dex, &new_place)
                 }
                 Context::DexMethod(method, dex_file) => {
                     let (multi_dex, dex_file) = if let Some((md, f)) =
@@ -211,7 +211,7 @@ fn find_references_to_string<'a: 'b, 'b>(
     let mut context_matches: Vec<Evidence> = vec![];
     let vec_loc = Arc::new(Mutex::new(&mut context_matches));
     let classes = multi_dex.classes();
-    iterator!(classes).for_each(|(_f, c)| {
+    iterator!(classes).for_each(|(f, c)| {
         let methods_containing_references: Vec<_> = iterator!(c.codes)
             .filter(|md| match md.code.as_ref() {
                 Some(code) => {
@@ -232,7 +232,7 @@ fn find_references_to_string<'a: 'b, 'b>(
             .map(|m| {
                 Evidence::CrossReference(CrossReferenceEvidence {
                     place: Location::DexMethod(m.method.method_idx as u32, dex_file.clone()),
-                    place_context: Context::DexMethod(m.method.clone(), dex_file.clone()),
+                    place_context: Context::DexMethod(m.method.clone(), f.clone()),
                     context: place.clone(),
                 })
             })
@@ -247,6 +247,7 @@ fn find_references_to_string<'a: 'b, 'b>(
 //TODO: refactor
 fn find_references_to_type<'a: 'b, 'b>(
     typ: u32,
+    name: &str,
     dex_file: Arc<DexFile>,
     multi_dex: &'a MultiDexFile,
     place: &'b Context,
@@ -262,17 +263,28 @@ fn find_references_to_type<'a: 'b, 'b>(
             .filter(|md| match md.code.as_ref() {
                 Some(code) => {
                     let references =
-                        iterator!(code.insns)
-                            .filter(|(_, _, instruction)| match instruction {
+                            iterator!(code.insns).filter(|(_, _, instruction)| match instruction {
                                 coeus_models::models::Instruction::Invoke(method_idx)
                                 | coeus_models::models::Instruction::InvokeVirtual(
                                     _,
                                     method_idx,
                                     _,
                                 )
-                                | coeus_models::models::Instruction::InvokeSuper(_, method_idx, _)
-                                | coeus_models::models::Instruction::InvokeDirect(_, method_idx, _)
-                                | coeus_models::models::Instruction::InvokeStatic(_, method_idx, _)
+                                | coeus_models::models::Instruction::InvokeSuper(
+                                    _,
+                                    method_idx,
+                                    _,
+                                )
+                                | coeus_models::models::Instruction::InvokeDirect(
+                                    _,
+                                    method_idx,
+                                    _,
+                                )
+                                | coeus_models::models::Instruction::InvokeStatic(
+                                    _,
+                                    method_idx,
+                                    _,
+                                )
                                 | coeus_models::models::Instruction::InvokeInterface(
                                     _,
                                     method_idx,
@@ -291,140 +303,13 @@ fn find_references_to_type<'a: 'b, 'b>(
                                 }
 
                                 coeus_models::models::Instruction::NewInstance(_, type_idx) => {
-                                    (*type_idx) == typ as u16
+                                    if let Some(s) = f.get_type_name(*type_idx as usize) {
+                                        s == name
+                                    } else {
+                                        false
+                                    }
                                 }
 
-                                coeus_models::models::Instruction::StaticGet(_, field_id)
-                                | coeus_models::models::Instruction::StaticGetWide(_, field_id)
-                                | coeus_models::models::Instruction::StaticGetObject(_, field_id)
-                                | coeus_models::models::Instruction::StaticGetBoolean(_, field_id)
-                                | coeus_models::models::Instruction::StaticGetByte(_, field_id)
-                                | coeus_models::models::Instruction::StaticGetChar(_, field_id)
-                                | coeus_models::models::Instruction::StaticGetShort(_, field_id)
-                                | coeus_models::models::Instruction::StaticPut(_, field_id)
-                                | coeus_models::models::Instruction::StaticPutWide(_, field_id)
-                                | coeus_models::models::Instruction::StaticPutObject(_, field_id)
-                                | coeus_models::models::Instruction::StaticPutBoolean(_, field_id)
-                                | coeus_models::models::Instruction::StaticPutByte(_, field_id)
-                                | coeus_models::models::Instruction::StaticPutChar(_, field_id)
-                                | coeus_models::models::Instruction::StaticPutShort(_, field_id)
-                                | coeus_models::models::Instruction::InstanceGet(_, _, field_id)
-                                | coeus_models::models::Instruction::InstanceGetWide(
-                                    _,
-                                    _,
-                                    field_id,
-                                )
-                                | coeus_models::models::Instruction::InstanceGetObject(
-                                    _,
-                                    _,
-                                    field_id,
-                                )
-                                | coeus_models::models::Instruction::InstanceGetBoolean(
-                                    _,
-                                    _,
-                                    field_id,
-                                )
-                                | coeus_models::models::Instruction::InstanceGetByte(
-                                    _,
-                                    _,
-                                    field_id,
-                                )
-                                | coeus_models::models::Instruction::InstanceGetChar(
-                                    _,
-                                    _,
-                                    field_id,
-                                )
-                                | coeus_models::models::Instruction::InstanceGetShort(
-                                    _,
-                                    _,
-                                    field_id,
-                                )
-                                | coeus_models::models::Instruction::InstancePut(_, _, field_id)
-                                | coeus_models::models::Instruction::InstancePutWide(
-                                    _,
-                                    _,
-                                    field_id,
-                                )
-                                | coeus_models::models::Instruction::InstancePutObject(
-                                    _,
-                                    _,
-                                    field_id,
-                                )
-                                | coeus_models::models::Instruction::InstancePutBoolean(
-                                    _,
-                                    _,
-                                    field_id,
-                                )
-                                | coeus_models::models::Instruction::InstancePutByte(
-                                    _,
-                                    _,
-                                    field_id,
-                                )
-                                | coeus_models::models::Instruction::InstancePutChar(
-                                    _,
-                                    _,
-                                    field_id,
-                                )
-                                | coeus_models::models::Instruction::InstancePutShort(
-                                    _,
-                                    _,
-                                    field_id,
-                                ) => match dex_file.fields.get((*field_id) as usize) {
-                                    Some(field) => field.class_idx == typ as u16,
-                                    _ => false,
-                                },
-                                _ => false,
-                            });
-                    references.count() > 0
-                }
-                None => false,
-            })
-            .map(|m| {
-                Evidence::CrossReference(CrossReferenceEvidence {
-                    place: Location::DexMethod(m.method.method_idx as u32, dex_file.clone()),
-                    place_context: Context::DexMethod(m.method.clone(), f.clone()),
-                    context: place.clone(),
-                })
-            })
-            .collect();
-        if let Ok(mut lock) = vec_loc.lock() {
-            lock.extend(methods_containing_references);
-        }
-    });
-    context_matches
-}
-
-fn find_references_to_field<'a: 'b, 'b>(
-    field_idx: &'b Field,
-    dex_file: Arc<DexFile>,
-    _multi_dex: &'a MultiDexFile,
-    place: &'b Context,
-) -> Vec<Evidence> {
-    let mut context_matches: Vec<Evidence> = vec![];
-    let vec_loc = Arc::new(Mutex::new(&mut context_matches));
-    let field_index = if let Some(f_i) = iterator!(dex_file.fields)
-        .enumerate()
-        .filter_map(|(idx, f)| {
-            if f.as_ref() == field_idx {
-                Some(idx)
-            } else {
-                None
-            }
-        })
-        .collect::<Vec<_>>()
-        .first()
-    {
-        *f_i as u16
-    } else {
-        return vec![];
-    };
-
-    iterator!(dex_file.classes).for_each(|c| {
-        let methods_containing_references: Vec<_> = iterator!(c.codes)
-            .filter_map(|md| match md.code.as_ref() {
-                Some(code) => {
-                    let references =
-                            iterator!(code.insns).filter(|(_, _, instruction)| match instruction {
                                 coeus_models::models::Instruction::StaticGet(_, field_id)
                                 | coeus_models::models::Instruction::StaticGetWide(_, field_id)
                                 | coeus_models::models::Instruction::StaticGetObject(_, field_id)
@@ -506,10 +391,115 @@ fn find_references_to_field<'a: 'b, 'b>(
                                     _,
                                     _,
                                     field_id,
-                                ) => *field_id == field_index,
-
+                                ) => match f.fields.get((*field_id) as usize) {
+                                    Some(field) => {
+                                        if let Some(type_name) = f.get_type_name(field.class_idx) {
+                                            type_name == name
+                                        } else {
+                                            false
+                                        }
+                                    }
+                                    _ => false,
+                                },
                                 _ => false,
                             });
+                    references.count() > 0
+                }
+                None => false,
+            })
+            .map(|m| {
+                Evidence::CrossReference(CrossReferenceEvidence {
+                    place: Location::DexMethod(m.method.method_idx as u32, dex_file.clone()),
+                    place_context: Context::DexMethod(m.method.clone(), f.clone()),
+                    context: place.clone(),
+                })
+            })
+            .collect();
+        if let Ok(mut lock) = vec_loc.lock() {
+            lock.extend(methods_containing_references);
+        }
+    });
+    context_matches
+}
+
+fn find_references_to_field<'a: 'b, 'b>(
+    field_idx: &'b Field,
+    dex_file: Arc<DexFile>,
+    multi_dex: &'a MultiDexFile,
+    place: &'b Context,
+) -> Vec<Evidence> {
+    let mut context_matches: Vec<Evidence> = vec![];
+    let vec_loc = Arc::new(Mutex::new(&mut context_matches));
+    let field_fqdn = format!(
+        "{}->{}",
+        dex_file
+            .get_type_name(field_idx.type_idx as usize)
+            .unwrap_or(""),
+        field_idx.name
+    );
+    let classes = multi_dex.classes();
+    iterator!(classes).for_each(|(f, c)| {
+        let methods_containing_references: Vec<_> = iterator!(c.codes)
+            .filter_map(|md| match md.code.as_ref() {
+                Some(code) => {
+                    let references =
+                        iterator!(code.insns).filter(|(_, _, instruction)| match instruction {
+                            coeus_models::models::Instruction::StaticGet(_, field_id)
+                            | coeus_models::models::Instruction::StaticGetWide(_, field_id)
+                            | coeus_models::models::Instruction::StaticGetObject(_, field_id)
+                            | coeus_models::models::Instruction::StaticGetBoolean(_, field_id)
+                            | coeus_models::models::Instruction::StaticGetByte(_, field_id)
+                            | coeus_models::models::Instruction::StaticGetChar(_, field_id)
+                            | coeus_models::models::Instruction::StaticGetShort(_, field_id)
+                            | coeus_models::models::Instruction::StaticPut(_, field_id)
+                            | coeus_models::models::Instruction::StaticPutWide(_, field_id)
+                            | coeus_models::models::Instruction::StaticPutObject(_, field_id)
+                            | coeus_models::models::Instruction::StaticPutBoolean(_, field_id)
+                            | coeus_models::models::Instruction::StaticPutByte(_, field_id)
+                            | coeus_models::models::Instruction::StaticPutChar(_, field_id)
+                            | coeus_models::models::Instruction::StaticPutShort(_, field_id)
+                            | coeus_models::models::Instruction::InstanceGet(_, _, field_id)
+                            | coeus_models::models::Instruction::InstanceGetWide(_, _, field_id)
+                            | coeus_models::models::Instruction::InstanceGetObject(
+                                _,
+                                _,
+                                field_id,
+                            )
+                            | coeus_models::models::Instruction::InstanceGetBoolean(
+                                _,
+                                _,
+                                field_id,
+                            )
+                            | coeus_models::models::Instruction::InstanceGetByte(_, _, field_id)
+                            | coeus_models::models::Instruction::InstanceGetChar(_, _, field_id)
+                            | coeus_models::models::Instruction::InstanceGetShort(_, _, field_id)
+                            | coeus_models::models::Instruction::InstancePut(_, _, field_id)
+                            | coeus_models::models::Instruction::InstancePutWide(_, _, field_id)
+                            | coeus_models::models::Instruction::InstancePutObject(
+                                _,
+                                _,
+                                field_id,
+                            )
+                            | coeus_models::models::Instruction::InstancePutBoolean(
+                                _,
+                                _,
+                                field_id,
+                            )
+                            | coeus_models::models::Instruction::InstancePutByte(_, _, field_id)
+                            | coeus_models::models::Instruction::InstancePutChar(_, _, field_id)
+                            | coeus_models::models::Instruction::InstancePutShort(_, _, field_id) =>
+                            {
+                                let field = f.fields[*field_id as usize].clone();
+                                let fqdn = format!(
+                                    "{}->{}",
+                                    f.get_type_name(field.type_idx as usize).unwrap_or(""),
+                                    field.name
+                                );
+                                fqdn == field_fqdn
+                            }
+
+                            _ => false,
+                        });
                     Some((md, references.collect::<Vec<_>>()))
                 }
                 None => None,
@@ -620,7 +610,7 @@ fn find_references_to_method<'a: 'b, 'b>(
 
 fn find_references_to_class<'a: 'b, 'b>(
     class_idx: &'b Class,
-    dex_file: Arc<DexFile>,
+    _dex_file: Arc<DexFile>,
     multi_dex: &'a MultiDexFile,
     place: &'b Context,
 ) -> Vec<Evidence> {
@@ -632,17 +622,28 @@ fn find_references_to_class<'a: 'b, 'b>(
             .filter(|md| match md.code.as_ref() {
                 Some(code) => {
                     let references =
-                        iterator!(code.insns)
-                            .filter(|(_, _, instruction)| match instruction {
+                            iterator!(code.insns).filter(|(_, _, instruction)| match instruction {
                                 coeus_models::models::Instruction::Invoke(method_idx)
                                 | coeus_models::models::Instruction::InvokeVirtual(
                                     _,
                                     method_idx,
                                     _,
                                 )
-                                | coeus_models::models::Instruction::InvokeSuper(_, method_idx, _)
-                                | coeus_models::models::Instruction::InvokeDirect(_, method_idx, _)
-                                | coeus_models::models::Instruction::InvokeStatic(_, method_idx, _)
+                                | coeus_models::models::Instruction::InvokeSuper(
+                                    _,
+                                    method_idx,
+                                    _,
+                                )
+                                | coeus_models::models::Instruction::InvokeDirect(
+                                    _,
+                                    method_idx,
+                                    _,
+                                )
+                                | coeus_models::models::Instruction::InvokeStatic(
+                                    _,
+                                    method_idx,
+                                    _,
+                                )
                                 | coeus_models::models::Instruction::InvokeInterface(
                                     _,
                                     method_idx,
@@ -661,20 +662,30 @@ fn find_references_to_class<'a: 'b, 'b>(
                                 }
 
                                 coeus_models::models::Instruction::NewInstance(_, type_idx) => {
-                                    (*type_idx) == class_idx.class_idx as u16
+                                    if let Some(s) = f.get_type_name(*type_idx as usize) {
+                                        s == &class_idx.class_name
+                                    } else {
+                                        false
+                                    }
                                 }
 
                                 coeus_models::models::Instruction::StaticGet(_, field_id)
                                 | coeus_models::models::Instruction::StaticGetWide(_, field_id)
                                 | coeus_models::models::Instruction::StaticGetObject(_, field_id)
-                                | coeus_models::models::Instruction::StaticGetBoolean(_, field_id)
+                                | coeus_models::models::Instruction::StaticGetBoolean(
+                                    _,
+                                    field_id,
+                                )
                                 | coeus_models::models::Instruction::StaticGetByte(_, field_id)
                                 | coeus_models::models::Instruction::StaticGetChar(_, field_id)
                                 | coeus_models::models::Instruction::StaticGetShort(_, field_id)
                                 | coeus_models::models::Instruction::StaticPut(_, field_id)
                                 | coeus_models::models::Instruction::StaticPutWide(_, field_id)
                                 | coeus_models::models::Instruction::StaticPutObject(_, field_id)
-                                | coeus_models::models::Instruction::StaticPutBoolean(_, field_id)
+                                | coeus_models::models::Instruction::StaticPutBoolean(
+                                    _,
+                                    field_id,
+                                )
                                 | coeus_models::models::Instruction::StaticPutByte(_, field_id)
                                 | coeus_models::models::Instruction::StaticPutChar(_, field_id)
                                 | coeus_models::models::Instruction::StaticPutShort(_, field_id)
@@ -739,8 +750,14 @@ fn find_references_to_class<'a: 'b, 'b>(
                                     _,
                                     _,
                                     field_id,
-                                ) => match dex_file.fields.get((*field_id) as usize) {
-                                    Some(field) => field.class_idx == class_idx.class_idx as u16,
+                                ) => match f.fields.get((*field_id) as usize) {
+                                    Some(field) => {
+                                        if let Some(class_name) = f.get_type_name(field.class_idx) {
+                                            class_name == class_idx.class_name
+                                        } else {
+                                            false
+                                        }
+                                    }
                                     _ => false,
                                 },
                                 _ => false,
@@ -751,8 +768,8 @@ fn find_references_to_class<'a: 'b, 'b>(
             })
             .map(|m| {
                 Evidence::CrossReference(CrossReferenceEvidence {
-                    place: Location::DexMethod(m.method.method_idx as u32, dex_file.clone()),
-                    place_context: Context::DexMethod(m.method.clone(), dex_file.clone()),
+                    place: Location::DexMethod(m.method.method_idx as u32, f.clone()),
+                    place_context: Context::DexMethod(m.method.clone(), f.clone()),
                     context: place.clone(),
                 })
             })
@@ -821,27 +838,18 @@ pub fn find_string_matches_for_type_name(
         let types = dex.types();
         let type_matches: Vec<Evidence> = iterator!(types)
             .filter(
-                |type_idx| match (**type_idx).0.strings.get(((**type_idx).1) as usize) {
+                |(dex_file, type_idx)| match dex_file.strings.get((*type_idx) as usize) {
                     Some(name) => reg.is_match(&name.to_str_lossy()),
                     None => false,
                 },
             )
-            .filter_map(|type_idx| {
-                let type_name = (*type_idx)
-                    .0
-                    .strings
-                    .get(((*type_idx).1) as usize)?
-                    .to_str()
-                    .ok()?;
+            .filter_map(|(dex_file, type_idx)| {
+                let type_name = dex_file.strings.get((*type_idx) as usize)?.to_str().ok()?;
 
                 Some(Evidence::String(StringEvidence {
                     content: type_name.to_owned(),
-                    place: Location::Type((*type_idx).1, (*type_idx).0.clone()),
-                    context: Context::DexType(
-                        (*type_idx).1,
-                        type_name.to_string(),
-                        (*type_idx).0.clone(),
-                    ),
+                    place: Location::Type(*type_idx, dex_file.clone()),
+                    context: Context::DexType(*type_idx, type_name.to_string(), dex_file.clone()),
                     confidence_level: ConfidenceLevel::Medium,
                 }))
             })

--- a/coeus/coeus_models/Cargo.toml
+++ b/coeus/coeus_models/Cargo.toml
@@ -19,6 +19,7 @@ goblin = "0.4.3"
 petgraph = "0.6.0"
 rand = {version = "0.8.3", features = ["getrandom"]}
 getrandom = "0.2"
+abxml = {version = "0.8.2", default-features = false}
 
 # rhai = {version = "1.1.0", optional = true}
 cesu8 = "1.1.0"

--- a/coeus/coeus_models/src/models/files.rs
+++ b/coeus/coeus_models/src/models/files.rs
@@ -1,18 +1,20 @@
 // Copyright (c) 2022 Ubique Innovation AG <https://www.ubique.ch>
-// 
+//
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use super::{BinaryObject, DexFile, MultiDexFile};
+use abxml::visitor::{Executor, ModelVisitor, XmlVisitor};
 use coeus_macros::iterator;
 use rayon::prelude::*;
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, io::Cursor, sync::Arc};
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct Files {
     pub multi_dex: Vec<MultiDexFile>,
     pub binaries: HashMap<String, Arc<BinaryObject>>,
+    pub binary_resource_file: Vec<u8>,
 }
 
 impl Files {
@@ -20,6 +22,7 @@ impl Files {
         Self {
             multi_dex,
             binaries,
+            binary_resource_file: vec![],
         }
     }
 
@@ -46,5 +49,12 @@ impl Files {
             .collect::<Vec<_>>()
             .first()
             .cloned()
+    }
+    pub fn decode_resource(&self, binary_xml: &[u8]) -> Option<String> {
+        let mut visitor = ModelVisitor::default();
+        Executor::arsc(&self.binary_resource_file, &mut visitor).ok()?;
+        let mut visitor = XmlVisitor::new(visitor.get_resources());
+        let _ = Executor::xml(Cursor::new(&binary_xml), &mut visitor);
+        visitor.into_string().ok()
     }
 }

--- a/coeus/coeus_models/src/models/instruction.rs
+++ b/coeus/coeus_models/src/models/instruction.rs
@@ -169,7 +169,7 @@ pub enum Instruction {
     SwitchData(Switch),
 }
 
-static MNEMONICS: [&str; 79] = [
+static MNEMONICS: [&str; 80] = [
     "nop",
     "const-string",
     "const-string/jumbo",
@@ -248,7 +248,8 @@ static MNEMONICS: [&str; 79] = [
     "move-result",
     "check-cast",
     "throw",
-    "move"
+    "move",
+    "const-class"
 ];
 
 impl Instruction {
@@ -737,7 +738,7 @@ impl Instruction {
                             .collect::<Vec<_>>()
                             .join("");
                         format!(
-                            "{} {{{}}} {}->{}({}){}",
+                            "{} {{{}}}, {}->{}({}){}",
                             MNEMONICS[37],
                             arg_regs
                                 .iter()
@@ -797,7 +798,12 @@ impl Instruction {
                         .unwrap_or("".to_string())
                 )
             }
-            &Instruction::InstancePut(src, obj, field) => {
+            &Instruction::ConstClass(dst, obj) => {
+                format!("{} v{}, {}", MNEMONICS[79], dst, file.get_type_name(obj).unwrap_or("INVALID"))
+            }
+            &Instruction::InstancePut(src, obj, field)
+            | &Instruction::InstancePutBoolean(src, obj, field)
+            | &Instruction::InstancePutByte(src, obj, field) => {
                 let instruction_type = file
                     .fields
                     .get(field as usize)

--- a/coeus/coeus_parse/src/extraction.rs
+++ b/coeus/coeus_parse/src/extraction.rs
@@ -103,6 +103,7 @@ pub fn extract_single_threaded(
     Files {
         multi_dex,
         binaries: other_files,
+        binary_resource_file: bin_res_file
     }
 }
 
@@ -127,6 +128,7 @@ pub fn extract_zip(
         return Files {
             multi_dex,
             binaries: other_files,
+            binary_resource_file: vec![]
         };
     };
 
@@ -210,6 +212,7 @@ pub fn extract_zip(
     Files {
         multi_dex,
         binaries: other_files,
+        binary_resource_file: bin_res_file
     }
 }
 


### PR DESCRIPTION
This PR fixes problems with finding references across dex files as `NewInstance` was wrongfully accessing the type_idx, which is specific to one dex file.

Second, we allow now the decoding of binary XML files.

And last, we added FieldReference and FieldAccess Evidence mapping.