### PR TITLE
Added a function get_method_by_proto_type.

### DIFF
--- a/coeus-python/coeus_python.pyi
+++ b/coeus-python/coeus_python.pyi
@@ -278,7 +278,7 @@ class Class:
     def get_method_by_signature(self, name: str, signature: str) -> Method:
         """Get a method of this class by name"""
     def __getitem__(self, name: str) -> Method:
-        """Get a method of this class by name"""
+        """Get a method of this class by name, input and return arguments"""
     def get_field(self, name: str) -> DexField:
         """Return an instance field"""
     def get_static_field(self, name: str) -> DexField:

--- a/coeus-python/coeus_python.pyi
+++ b/coeus-python/coeus_python.pyi
@@ -274,6 +274,8 @@ class Class:
     def get_methods(self) -> list[Method]:
         """Get all methods found on this class"""
     def get_method(self, name: str) -> Method:
+        """Get all methods found on this class"""
+    def get_method_by_signature(self, name: str, signature: str) -> Method:
         """Get a method of this class by name"""
     def __getitem__(self, name: str) -> Method:
         """Get a method of this class by name"""

--- a/coeus-python/coeus_python.pyi
+++ b/coeus-python/coeus_python.pyi
@@ -275,7 +275,7 @@ class Class:
         """Get all methods found on this class"""
     def get_method(self, name: str) -> Method:
         """Get a method of this class by name"""
-    def get_method_by_signature(self, name: str, signature: str) -> Method:
+    def get_method_by_proto_type(self, name: str, signature: str) -> Method:
         """Get a method of this class by name, input arguments and return value"""
     def __getitem__(self, name: str) -> Method:
         """Get a method of this class by name"""

--- a/coeus-python/coeus_python.pyi
+++ b/coeus-python/coeus_python.pyi
@@ -274,11 +274,11 @@ class Class:
     def get_methods(self) -> list[Method]:
         """Get all methods found on this class"""
     def get_method(self, name: str) -> Method:
-        """Get all methods found on this class"""
-    def get_method_by_signature(self, name: str, signature: str) -> Method:
         """Get a method of this class by name"""
+    def get_method_by_signature(self, name: str, signature: str) -> Method:
+        """Get a method of this class by name, input arguments and return value"""
     def __getitem__(self, name: str) -> Method:
-        """Get a method of this class by name, input and return arguments"""
+        """Get a method of this class by name"""
     def get_field(self, name: str) -> DexField:
         """Return an instance field"""
     def get_static_field(self, name: str) -> DexField:

--- a/coeus-python/src/analysis.rs
+++ b/coeus-python/src/analysis.rs
@@ -1722,11 +1722,11 @@ impl Class {
             .ok_or_else(|| PyRuntimeError::new_err("method not found"))
     }
 
-    pub fn get_method_by_proto_type(&self,name: &str, signature: &str) -> PyResult<Method> {
+    pub fn get_method_by_proto_type(&self,name: &str, proto_name: &str) -> PyResult<Method> {
         self.class
             .codes
             .iter()
-            .find(|a| (a.method.method_name == name) && (a.method.proto_name == signature))
+            .find(|a| (a.method.method_name == name) && (a.method.proto_name == proto_name))
             .map(|method| Method {
                 method: method.method.clone(),
                 method_data: Some(method.clone()),

--- a/coeus-python/src/analysis.rs
+++ b/coeus-python/src/analysis.rs
@@ -1722,6 +1722,20 @@ impl Class {
             .ok_or_else(|| PyRuntimeError::new_err("method not found"))
     }
 
+    pub fn get_method_by_proto_type(&self,name: &str, signature: &str) -> PyResult<Method> {
+        self.class
+            .codes
+            .iter()
+            .find(|a| (a.method.method_name == name) && (a.method.proto_name == signature))
+            .map(|method| Method {
+                method: method.method.clone(),
+                method_data: Some(method.clone()),
+                file: self.file.clone(),
+                class: self.class.clone(),
+            })
+            .ok_or_else(|| PyRuntimeError::new_err("method not found"))
+    }
+
     pub fn get_field(&self, name: &str) -> PyResult<DexField> {
         let class_data = if let Some(c_d) = self.class.class_data.as_ref() {
             c_d

--- a/coeus-python/src/parse.rs
+++ b/coeus-python/src/parse.rs
@@ -377,7 +377,7 @@ impl AnalyzeObject {
             .collect())
     }
 
-    /// Find methods in the analyzed object by utilising a regular expression
+    /// Find fields in the analyzed object by utilising a regular expression
     #[pyo3(text_signature = "($self, name,/)")]
     pub fn find_fields(&self, name: &str) -> PyResult<Vec<crate::analysis::Evidence>> {
         let regex = Regex::new(name).map_err(|e| PyRuntimeError::new_err(format!("{:?}", e)))?;
@@ -387,7 +387,7 @@ impl AnalyzeObject {
             .map(|evidence| crate::analysis::Evidence { evidence })
             .collect())
     }
-    /// Find methods in the analyzed object by utilising a regular expression
+    /// Find strings in the analyzed object by utilising a regular expression
     #[pyo3(text_signature = "($self, name,/)")]
     pub fn find_strings(&self, name: &str) -> PyResult<Vec<crate::analysis::Evidence>> {
         let regex = Regex::new(name).map_err(|e| PyRuntimeError::new_err(format!("{:?}", e)))?;


### PR DESCRIPTION
If a (potentially obfuscated) class has multiple methods with the same name,
the function Class.get_method($self, name: &str) is not able to retrieve all
of them.

So we added a function get_method_by_proto_type(&self, name: &str, proto_name: &str)
where we can specify the input and return parameters of the method additionally.

Example:

```
>>> from coeus_python import AnalyzeObject
>>> ao = AnalyzeObject("test.apk", False, 1)
>>> classes = ao.find_classes("Lcom/a/b/c//clazz;");
>>> cl = classes[0]
>>> clc = cl.as_class()
>>> clc.get_method_by_proto_type("a","(Ljava/lang/String;)Ljava/lang/String;");
"Lcom/a/b/c//clazz;->a(Ljava/lang/String;)Ljava/lang/String;"
>>> clc.get_method_by_proto_type("a", "([C[BI)I")
"Lcom/a/b/c//clazz;->a([C[BI)I
>>> clc.get_method("a")
"Lcom/a/b/c//clazz;->a([C[BI)I
```