### PR TITLE
Extract launcher images with Coeus 

### DIFF
--- a/coeus-python/coeus_python.pyi
+++ b/coeus-python/coeus_python.pyi
@@ -399,3 +399,5 @@ class AnalyzeObject:
         """Get file bytes"""
     def get_resource_string(self, id: int) -> tuple[str, dict[str, str]]:
         """Lookup the string table"""
+    def get_resource_mipmap_file_name(self, id: int) -> tuple[str, dict[str, str]]:
+        """Get a mipmap file name"""

--- a/coeus-python/coeus_python.pyi
+++ b/coeus-python/coeus_python.pyi
@@ -397,5 +397,5 @@ class AnalyzeObject:
         """Get the primary dex files"""
     def get_file(self, name: str) -> bytes:
         """Get file bytes"""
-    def get_resource_string(self, id: int) -> str:
+    def get_resource_string(self, id: int) -> tuple[str, dict[str, str]]:
         """Lookup the string table"""

--- a/coeus-python/src/parse.rs
+++ b/coeus-python/src/parse.rs
@@ -16,7 +16,6 @@ use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use regex::Regex;
 use std::collections::HashMap;
-use std::hash::Hash;
 use std::sync::Arc;
 
 use crate::analysis::DexString;

--- a/coeus-python/src/parse.rs
+++ b/coeus-python/src/parse.rs
@@ -16,6 +16,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use regex::Regex;
 use std::collections::HashMap;
+use std::hash::Hash;
 use std::sync::Arc;
 
 use crate::analysis::DexString;
@@ -169,6 +170,13 @@ impl AnalyzeObject {
             let _ = self.files.load_arsc();
         }
         self.files.get_string_from_resource(id)
+    }
+
+    pub fn get_resource_mipmap_file_name(&mut self, id: u32) -> Option<(String, HashMap<String,String>)> {
+        if self.files.arsc.is_none() {
+            let _ = self.files.load_arsc();
+        }
+        self.files.get_mipmap_file_name_from_resource(id)       
     }
 
     pub fn get_file(&self, py: Python, name: &str) -> PyObject {


### PR DESCRIPTION
To extract the file names of the launcher icons, the function `get_mipmap_file_name_from_resource` was added.

Let 2131492864 be the id of the ic_launcher.

With the following lines you get the file name(s) of the launcher icon.

```
from coeus_python import AnalyzeObject
ao=AnalyzeObject("test.apk", False, 0)

file_name = ao.get_resource_mipmap_file_name(2131492864)
print(file_name)
```

**`('ic_launcher', {'ANYDPI-v26': 'res/BW.xml', 'XXXHDPI': 'res/o-.png', 'MDPI': 'res/9w.png', 'XHDPI': 'res/FS.png', 'HDPI': 'res/yn.png', 'XXHDPI': 'res/RJ.png'})`**